### PR TITLE
Founded bug in InformationClient

### DIFF
--- a/src/main/java/sky/group/homeworkgroup/model/InformationClient.java
+++ b/src/main/java/sky/group/homeworkgroup/model/InformationClient.java
@@ -11,6 +11,18 @@ public class InformationClient {
     private String typeProduct;
     private String nameProduct;
 
+    private final String debit;
+    private final String deposit;
+    private final int i;
+
+
+    public InformationClient(String debit, String deposit, int i) {
+        super();
+        this.debit = debit;
+        this.deposit = deposit;
+        this.i = i;
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/test/java/sky/group/homeworkgroup/logic/LogicTest.java
+++ b/src/test/java/sky/group/homeworkgroup/logic/LogicTest.java
@@ -1,0 +1,53 @@
+package sky.group.homeworkgroup.logic;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import sky.group.homeworkgroup.model.InformationClient;
+import sky.group.homeworkgroup.repository.ProjectRepository;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+public class LogicTest {
+    @Mock
+    private ProjectRepository projectRepository;
+
+    private Logic logic;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        logic = new Logic(projectRepository);
+    }
+
+    @Test
+    void testNoTransactions() {
+        UUID testId = UUID.randomUUID();
+        when(projectRepository.getListTransactions(testId)).thenReturn(Collections.emptyList());
+
+        List<UUID> result = logic.analise(testId);
+
+        assertEquals(0, result.size());
+    }
+
+    @Test
+    void testEdgeCaseTransactions() {
+        UUID testId = UUID.randomUUID();
+        InformationClient transaction1 = new InformationClient("DEBIT", "DEPOSIT", 1000);
+        InformationClient transaction2 = new InformationClient("DEBIT", "EXPENSE", 100_000);
+        when(projectRepository.getListTransactions(testId)).thenReturn(List.of(transaction1, transaction2));
+
+        List<UUID> result = logic.analise(testId);
+
+        assertEquals(1, result.size());
+        assertEquals(UUID.fromString("ab138afb-f3ba-4a93-b74f-0fcee86d447f"), result.get(0));
+    }
+
+    // Additional tests for other corner cases can be added here
+}

--- a/src/test/java/sky/group/homeworkgroup/service/ServiceTest.java
+++ b/src/test/java/sky/group/homeworkgroup/service/ServiceTest.java
@@ -1,0 +1,38 @@
+package sky.group.homeworkgroup.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import sky.group.homeworkgroup.logic.Logic;
+import sky.group.homeworkgroup.model.OutputData;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.when;
+
+public class ServiceTest {
+    @Mock
+    private Logic logic;
+
+    private ServiceClient serviceClient;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        serviceClient = new ServiceClient(logic);
+    }
+
+    @Test
+    void testSearchForRecommendations() {
+        UUID testId = UUID.randomUUID();
+        when(logic.analise(testId)).thenReturn(List.of(UUID.fromString("147f6a0f-3b91-413b-ab99-87f081d60d5a")));
+
+        List<OutputData> result = serviceClient.searchForRecommendations(testId);
+
+        assertNotNull(result);
+        // Additional assertions can be added here to verify the contents of the result
+    }
+}


### PR DESCRIPTION
Саша, нашел баг в слое бизнес-логики. Бины корректно не проинжектировались. Надо размаппить в JPA-формат с помощью аннотаций. Maintainer не я и потому запустить процедуру с пометкой bug не могу. Поправь и это тоже. Corner cases не отрабатывают